### PR TITLE
change methods in DiscordClient#getRooms

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<dependency>
 			<groupId>org.javacord</groupId>
 			<artifactId>javacord</artifactId>
-			<version>3.1.2</version>
+			<version>3.3.0</version>
 			<type>pom</type>
 		</dependency>
 		<dependency>

--- a/src/main/java/com/hiyoko/discord/bot/BCDice/ChatTool/DiscordClient.java
+++ b/src/main/java/com/hiyoko/discord/bot/BCDice/ChatTool/DiscordClient.java
@@ -18,6 +18,11 @@ public class DiscordClient implements ChatToolClient {
 			+ "# サーバを一覧する\n"
 			+ "> bcdicediscord PASSWORD listServers";
 
+	public DiscordClient(DiscordApi api, String password) {
+		this.api = api;
+		this.password = password;
+	}
+
 	public DiscordClient(DiscordApi api) {
 		this.api = api;
 		this.password = getPassword();
@@ -61,7 +66,10 @@ public class DiscordClient implements ChatToolClient {
 	private List<String> getRooms() {
 		return api.getChannels().stream().filter(channel->{
 			return channel.getType().isTextChannelType();
-		}).map(channel->String.format("%s\t%s\t%s", channel.getIdAsString(), channel.asServerChannel().get().getName() , channel.asServerChannel().get().getServer().getName())).collect(Collectors.toList());
+		}).map(channel->String.format("%s\t%s\t%s",
+				channel.getIdAsString(),
+				channel.asServerTextChannel().get().getName(),
+				channel.asServerTextChannel().get().getServer().getName())).collect(Collectors.toList());
 	}
 
 	private List<String> getServerList() {


### PR DESCRIPTION
```
java.util.NoSuchElementException: No value present
        at java.util.Optional.get(Optional.java:148) ~[?:?]
        at com.hiyoko.discord.bot.BCDice.ChatTool.DiscordClient.lambda$getRooms$13(DiscordClient.java:59) ~[discord-bcdicebot_2_2_0.jar:?]
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195) ~[?:?]
        at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177) ~[?:?]
        at java.util.Iterator.forEachRemaining(Iterator.java:133) ~[?:?]
        at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801) ~[?:?]
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) ~[?:?]
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) ~[?:?]
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913) ~[?:?]
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
        at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578) ~[?:?]
        at com.hiyoko.discord.bot.BCDice.ChatTool.DiscordClient.getRooms(DiscordClient.java:59) ~[discord-bcdicebot_2_2_0.jar:?]
        at com.hiyoko.discord.bot.BCDice.ChatTool.DiscordClient.input(DiscordClient.java:38) ~[discord-bcdicebot_2_2_0.jar:?]
        at com.hiyoko.discord.bot.BCDice.BCDiceBot.lambda$null$4(BCDiceBot.java:83) ~[discord-bcdicebot_2_2_0.jar:?]
        at org.javacord.core.util.event.EventDispatcher.lambda$dispatchMessageCreateEvent$102(EventDispatcher.java:3636) ~[discord-bcdicebot_2_2_0.jar:?]
        at org.javacord.core.util.event.EventDispatcherBase.lambda$dispatchEvent$10(EventDispatcherBase.java:197) ~[discord-bcdicebot_2_2_0.jar:?]
        at org.javacord.core.util.event.EventDispatcherBase.lambda$checkRunningListenersAndStartIfPossible$17(EventDispatcherBase.java:265) ~[discord-bcdicebot_2_2_0.jar:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at java.lang.Thread.run(Thread.java:834) [?:?]
```

ただ、ローカルで試したときには問題が出ないのでこの修正が解決策には見えていない。